### PR TITLE
refactor: 게시글 생성 url 변경 및 응답 코드 수정

### DIFF
--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
@@ -2,6 +2,7 @@ package ajaajaja.debuging_rounge.domain.question.controller;
 
 import ajaajaja.debuging_rounge.domain.question.service.QuestionService;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
+import ajaajaja.debuging_rounge.global.util.UriHelper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/question")
+@RequestMapping("/questions")
 public class QuestionController {
 
     private final QuestionService questionService;
@@ -19,6 +20,9 @@ public class QuestionController {
     public ResponseEntity<Long> createQuestion(@RequestBody @Valid QuestionCreateRequestDto questionCreateRequestDto) {
         Long questionId = questionService.createQuestion(questionCreateRequestDto);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(questionId);
+        return ResponseEntity
+                .created(UriHelper.buildCreatedUri(questionId))
+                .body(questionId);
     }
+
 }

--- a/src/main/java/ajaajaja/debuging_rounge/global/util/UriHelper.java
+++ b/src/main/java/ajaajaja/debuging_rounge/global/util/UriHelper.java
@@ -1,0 +1,15 @@
+package ajaajaja.debuging_rounge.global.util;
+
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+
+import java.net.URI;
+
+public class UriHelper {
+    public static URI buildCreatedUri(Long id) {
+        return ServletUriComponentsBuilder
+                .fromCurrentRequest()
+                .path("/{id}")
+                .buildAndExpand(id)
+                .toUri();
+    }
+}


### PR DESCRIPTION
# refactor: 게시글 생성 API URL을 복수형으로 변경 및 응답에 Location 헤더와 ID 포함

- 게시글 생성 URL을 /question → /questions로 변경
단수형은 단일 게시글 생성이라는 의미를 명확히 전달할 수 있지만, 전체 API에서 복수/단수 혼용을 피하고 일관성을 유지하기 위해 복수형으로 통일함.

- 게시글 생성 성공 시, 응답 헤더에 Location 추가
RESTful한 설계 원칙에 따라, POST로 자원을 생성하면 Location 헤더를 통해 새로 생성된 자원의 URI를 클라이언트에게 제공함.
프론트엔드에서 별도로 URI를 재구성하지 않고도 바로 접근 가능하도록 하기 위함.

- 응답 Body에도 ID 포함
1. 단순히 ID만 필요한 경우, 프론트엔드가 Location 헤더에서 직접 파싱하는 것은 번거롭고 비효율적

2. 테스트 및 디버깅 시에도 Body에서 확인하는 것이 더 직관적이며 편리함
→ 결국 프론트와 백엔드 모두의 개발 편의를 위해 ID를 body에도 포함함.