### PR TITLE
feat: 게시글 단일 조회 기능 추가

### DIFF
--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
@@ -1,5 +1,6 @@
 package ajaajaja.debuging_rounge.domain.question.controller;
 
+import ajaajaja.debuging_rounge.domain.question.dto.QuestionDetailResponseDto;
 import ajaajaja.debuging_rounge.domain.question.service.QuestionService;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
 import ajaajaja.debuging_rounge.global.util.UriHelper;
@@ -25,4 +26,8 @@ public class QuestionController {
                 .body(questionId);
     }
 
+    @GetMapping("/{id}")
+    public ResponseEntity<QuestionDetailResponseDto> findQuestion(@PathVariable("id") Long id) {
+        return ResponseEntity.ok(questionService.findQuestionById(id));
+    }
 }

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/dto/QuestionDetailResponseDto.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/dto/QuestionDetailResponseDto.java
@@ -1,0 +1,21 @@
+package ajaajaja.debuging_rounge.domain.question.dto;
+
+import ajaajaja.debuging_rounge.domain.question.entity.Question;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class QuestionDetailResponseDto {
+
+    private final Long id;
+
+    private final String title;
+
+    private final String content;
+
+    public static QuestionDetailResponseDto fromEntity(Question question) {
+        return new QuestionDetailResponseDto(question.getId(), question.getTitle(), question.getContent());
+    }
+
+}

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
@@ -1,8 +1,10 @@
 package ajaajaja.debuging_rounge.domain.question.service;
 
+import ajaajaja.debuging_rounge.domain.question.dto.QuestionDetailResponseDto;
 import ajaajaja.debuging_rounge.domain.question.entity.Question;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
 import ajaajaja.debuging_rounge.domain.question.repository.QuestionRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,5 +20,12 @@ public class QuestionService {
         Question savedQuestion = questionRepository.save(question);
 
         return savedQuestion.getId();
+    }
+
+    public QuestionDetailResponseDto findQuestionById(Long id) {
+        Question question = questionRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("질문을 찾을 수 없습니다."));
+
+        return QuestionDetailResponseDto.fromEntity(question);
     }
 }


### PR DESCRIPTION
현재 QuestionService에서 애플리케이션 계층의 DTO(QuestionCreateRequestDto, QuestionDetailResponseDto)를 직접 사용하는 구조는, 계층 간의 관심사 분리가 명확히 이루어지지 않았다는 신호이다.

DTO는 주로 컨트롤러와 같은 외부 I/O 계층에서 요청/응답 모델로 활용되는 객체로, 서비스 계층이나 도메인 로직과는 분리되어야 바람직해 보인다.

물론 현재 규모 상 크게 문제되진 않지만, 도메인 모델이 외부 API 스펙에 종속되거나 DTO 변경 시 서비스 로직까지 ripple effect가 발생하는 등 점차 유지보수가 어려워지고 확장성에도 제약을 줄 수 있다.

특히 이 프로젝트는 단순한 기능 구현을 넘어서, 대규모 시스템을 염두에 둔 예비 설계 연습이라는 점에서 중장기적으로는 다음과 같은 구조적 개선이 필요하다.

1. DTO ↔ 도메인 객체 간의 변환 계층 도입 (예: Mapper, Converter)

2. Use Case 계층 또는 Application Service 계층 도입을 통한 명확한 경계 설정

3. CQRS 패턴 적용 가능성 검토 (Query/Command 객체 분리)

추후에 이를 통해 각 계층이 자신의 책임에만 집중할 수 있는 구조로 진화시켜, 변경에 유연하고 테스트하기 쉬운 시스템을 설계해야 한다.