### PR TITLE
feat: 게시글 전체 조회 기능 추가

### DIFF
--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
@@ -1,6 +1,7 @@
 package ajaajaja.debuging_rounge.domain.question.controller;
 
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionDetailResponseDto;
+import ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionUpdateRequestDto;
 import ajaajaja.debuging_rounge.domain.question.service.QuestionService;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
@@ -9,6 +10,8 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -24,6 +27,12 @@ public class QuestionController {
         return ResponseEntity
                 .created(UriHelper.buildCreatedUri(questionId))
                 .body(questionId);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<QuestionListResponseDto>> findAllQuestions() {
+        List<QuestionListResponseDto> questions = questionService.findAllQuestions();
+        return ResponseEntity.ok(questions);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
@@ -30,8 +30,8 @@ public class QuestionController {
     }
 
     @GetMapping
-    public ResponseEntity<List<QuestionListResponseDto>> findAllQuestions() {
-        List<QuestionListResponseDto> questions = questionService.findAllQuestions();
+    public ResponseEntity<List<QuestionListResponseDto>> findQuestionsWithPreview() {
+        List<QuestionListResponseDto> questions = questionService.findQuestionsWithPreview();
         return ResponseEntity.ok(questions);
     }
 

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/controller/QuestionController.java
@@ -8,10 +8,10 @@ import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
 import ajaajaja.debuging_rounge.global.util.UriHelper;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -30,8 +30,8 @@ public class QuestionController {
     }
 
     @GetMapping
-    public ResponseEntity<List<QuestionListResponseDto>> findQuestionsWithPreview() {
-        List<QuestionListResponseDto> questions = questionService.findQuestionsWithPreview();
+    public ResponseEntity<Page<QuestionListResponseDto>> findQuestionsWithPreview(Pageable pageable) {
+        Page<QuestionListResponseDto> questions = questionService.findQuestionsWithPreview(pageable);
         return ResponseEntity.ok(questions);
     }
 

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/dto/QuestionListResponseDto.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/dto/QuestionListResponseDto.java
@@ -19,8 +19,8 @@ public class QuestionListResponseDto {
                 .replaceAll("\\s{2,}", " ")     // 연속 공백 하나로
                 .trim(); // 앞뒤 공백 제거
 
-        return cleaned.length() > 100
-                ? cleaned.substring(0, 100) + "..."
+        return cleaned.length() > 50
+                ? cleaned.substring(0, 50) + "..."
                 : cleaned;
     }
 }

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/dto/QuestionListResponseDto.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/dto/QuestionListResponseDto.java
@@ -1,0 +1,26 @@
+package ajaajaja.debuging_rounge.domain.question.dto;
+
+import lombok.Getter;
+
+@Getter
+public class QuestionListResponseDto {
+    private final String title;
+    private final String previewContent;
+
+    public QuestionListResponseDto(String title, String contentSnippet) {
+        this.title = title;
+        this.previewContent = cleanAndTrim(contentSnippet);
+    }
+
+    private String cleanAndTrim(String rawContent) {
+        if (rawContent == null) return "";
+        String cleaned = rawContent
+                .replaceAll("[\\r\\n]+", " ")   // 줄바꿈 제거
+                .replaceAll("\\s{2,}", " ")     // 연속 공백 하나로
+                .trim(); // 앞뒤 공백 제거
+
+        return cleaned.length() > 100
+                ? cleaned.substring(0, 100) + "..."
+                : cleaned;
+    }
+}

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/repository/QuestionRepository.java
@@ -11,6 +11,6 @@ import java.util.List;
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
-    @Query("SELECT new ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto(q.title, SUBSTRING(q.content, 1, 200)) FROM Question q")
-    List<QuestionListResponseDto> findAllWithPreview();
+    @Query("SELECT new ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto(q.title, SUBSTRING(q.content, 1, 100)) FROM Question q")
+    List<QuestionListResponseDto> findQuestionsWithPreview();
 }

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/repository/QuestionRepository.java
@@ -2,15 +2,15 @@ package ajaajaja.debuging_rounge.domain.question.repository;
 
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto;
 import ajaajaja.debuging_rounge.domain.question.entity.Question;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
-
-import java.util.List;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
     @Query("SELECT new ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto(q.title, SUBSTRING(q.content, 1, 100)) FROM Question q")
-    List<QuestionListResponseDto> findQuestionsWithPreview();
+    Page<QuestionListResponseDto> findQuestionsWithPreview(Pageable pageable);
 }

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/repository/QuestionRepository.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/repository/QuestionRepository.java
@@ -1,10 +1,16 @@
 package ajaajaja.debuging_rounge.domain.question.repository;
 
+import ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto;
 import ajaajaja.debuging_rounge.domain.question.entity.Question;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 
+    @Query("SELECT new ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto(q.title, SUBSTRING(q.content, 1, 200)) FROM Question q")
+    List<QuestionListResponseDto> findAllWithPreview();
 }

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
@@ -8,9 +8,9 @@ import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
 import ajaajaja.debuging_rounge.domain.question.exception.QuestionNotFoundForDeleteException;
 import ajaajaja.debuging_rounge.domain.question.repository.QuestionRepository;
 import ajaajaja.debuging_rounge.domain.question.exception.QuestionNotFoundException;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -28,8 +28,8 @@ public class QuestionService {
         return savedQuestion.getId();
     }
 
-    public List<QuestionListResponseDto> findAllQuestions() {
-        return questionRepository.findAllWithPreview();
+    public List<QuestionListResponseDto> findQuestionsWithPreview() {
+        return questionRepository.findQuestionsWithPreview();
     }
 
     public QuestionDetailResponseDto findQuestionById(Long id) {

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
@@ -9,10 +9,10 @@ import ajaajaja.debuging_rounge.domain.question.exception.QuestionNotFoundForDel
 import ajaajaja.debuging_rounge.domain.question.repository.QuestionRepository;
 import ajaajaja.debuging_rounge.domain.question.exception.QuestionNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,8 +28,8 @@ public class QuestionService {
         return savedQuestion.getId();
     }
 
-    public List<QuestionListResponseDto> findQuestionsWithPreview() {
-        return questionRepository.findQuestionsWithPreview();
+    public Page<QuestionListResponseDto> findQuestionsWithPreview(Pageable pageable) {
+        return questionRepository.findQuestionsWithPreview(pageable);
     }
 
     public QuestionDetailResponseDto findQuestionById(Long id) {

--- a/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
+++ b/src/main/java/ajaajaja/debuging_rounge/domain/question/service/QuestionService.java
@@ -1,6 +1,7 @@
 package ajaajaja.debuging_rounge.domain.question.service;
 
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionDetailResponseDto;
+import ajaajaja.debuging_rounge.domain.question.dto.QuestionListResponseDto;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionUpdateRequestDto;
 import ajaajaja.debuging_rounge.domain.question.entity.Question;
 import ajaajaja.debuging_rounge.domain.question.dto.QuestionCreateRequestDto;
@@ -10,6 +11,8 @@ import ajaajaja.debuging_rounge.domain.question.exception.QuestionNotFoundExcept
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +26,10 @@ public class QuestionService {
         Question savedQuestion = questionRepository.save(question);
 
         return savedQuestion.getId();
+    }
+
+    public List<QuestionListResponseDto> findAllQuestions() {
+        return questionRepository.findAllWithPreview();
     }
 
     public QuestionDetailResponseDto findQuestionById(Long id) {


### PR DESCRIPTION
게시글 목록 조회 시 미리보기(최대 100글자) 구현

**1. 게시글 본문 일부만 조회하도록 DB 쿼리 최적화**
- SUBSTRING(content, 1, 200) 방식으로 본문을 일부만 조회
- DB 부하는 조금 증가하지만 전체 본문을 애플리케이션으로 가져온 뒤 잘라내는 방식보다 효율적
    - 네트워크 전송량 최소화
    - 글이 길수록 더 빠름 (긴 글을 짧게 잘라 전송)
    - 전체 SELECT 대비 DB IO 및 메모리 절약

**2. Java에서 UI 최적화 정제 로직 적용**
- DB에서 가져온 내용에 대해 줄바꿈, 연속 공백, 특수문자 등 제거
- 유지보수와 가독성 측면에서 Java가 유리
    - DB에서 정제 시 가독성 낮음, 로직 추가할수록 복잡도 증가, 깔끔한 처리 어려움
    - Java는 로직이 간결하고 가독성이 높음
    - 테스트 용이하고 다양한 정제 케이스 대응 가능
    - 유지보수 및 기능 확장에 유리

**3. 백엔드에서 미리보기 전처리를 담당하도록 구조화**
- 커뮤니티 목록, 검색 결과 등 서버에서 통일된 미리보기 제공
- 프론트에서는 렌더링만 담당
- 필요 시 캐싱, 검색 정렬 등에도 활용 가능

- 프론트엔드에서 처리하는 게 적합한 경우는 다음과 같음
    - 반응형 UI, 카드형 렌더링
    - "더보기" 기능 UI가 필요
    - 디바이스에 따라 줄임 기준이 달라야 할 때

**4. 구현 방식 요약**
- DB: SUBSTRING으로 본문 일부(200자)만 가져옴
- Java: 줄바꿈/공백 제거 후, 미리보기 텍스트를 100자로 자름