### PR TITLE
refactor: 수정/삭제 권한 판단을 프론트-> 백엔드로 변경

### DIFF
--- a/src/main/java/ajaajaja/debugging_rounge/common/security/annotation/CurrentUserIdArgumentResolver.java
+++ b/src/main/java/ajaajaja/debugging_rounge/common/security/annotation/CurrentUserIdArgumentResolver.java
@@ -20,7 +20,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
-        return parameter.hasParameterAnnotation(CurrentUserId.class);
+        return parameter.hasParameterAnnotation(LoginUserId.class);
     }
 
     @Override
@@ -28,7 +28,7 @@ public class CurrentUserIdArgumentResolver implements HandlerMethodArgumentResol
                                   ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) {
-        CurrentUserId ann = parameter.getParameterAnnotation(CurrentUserId.class);
+        LoginUserId ann = parameter.getParameterAnnotation(LoginUserId.class);
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
         if (!ann.required()) {

--- a/src/main/java/ajaajaja/debugging_rounge/common/security/annotation/LoginUserId.java
+++ b/src/main/java/ajaajaja/debugging_rounge/common/security/annotation/LoginUserId.java
@@ -7,6 +7,6 @@ import java.lang.annotation.Target;
 
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface CurrentUserId {
+public @interface LoginUserId {
     boolean required() default true;
 }

--- a/src/main/java/ajaajaja/debugging_rounge/feature/answer/api/AnswerController.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/answer/api/AnswerController.java
@@ -1,6 +1,6 @@
 package ajaajaja.debugging_rounge.feature.answer.api;
 
-import ajaajaja.debugging_rounge.common.security.annotation.CurrentUserId;
+import ajaajaja.debugging_rounge.common.security.annotation.LoginUserId;
 import ajaajaja.debugging_rounge.common.util.UriHelper;
 import ajaajaja.debugging_rounge.feature.answer.api.dto.AnswerCreateRequest;
 import ajaajaja.debugging_rounge.feature.answer.api.dto.AnswerDetailResponse;
@@ -28,7 +28,7 @@ public class AnswerController {
     public ResponseEntity<Long> createAnswer(
             @PathVariable("questionId") Long questionId,
             @RequestBody @Valid AnswerCreateRequest answerCreateRequest,
-            @CurrentUserId Long userId
+            @LoginUserId Long userId
     ) {
         Long answerId = createAnswerUseCase.createAnswer(answerCreateRequest.toDto(questionId, userId));
         return ResponseEntity
@@ -39,7 +39,7 @@ public class AnswerController {
     @GetMapping("/questions/{questionId}/answers")
     public ResponseEntity<Page<AnswerDetailResponse>> getAnswersByQuestionId(
             @PathVariable("questionId") Long questionId,
-            @CurrentUserId Long currentUserId,
+            @LoginUserId Long currentUserId,
             Pageable pageable
     ) {
         Page<AnswerDetailDto> answersPage = getAnswersQuery.findAllByQuestionId(questionId, pageable);

--- a/src/main/java/ajaajaja/debugging_rounge/feature/answer/api/dto/AnswerDetailResponse.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/answer/api/dto/AnswerDetailResponse.java
@@ -4,6 +4,6 @@ public record AnswerDetailResponse(
         Long id,
         String content,
         Long userId,
-        Long loginUserId
+        Boolean mine
 ) {
 }

--- a/src/main/java/ajaajaja/debugging_rounge/feature/answer/api/mapper/AnswerMapper.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/answer/api/mapper/AnswerMapper.java
@@ -2,12 +2,12 @@ package ajaajaja.debugging_rounge.feature.answer.api.mapper;
 
 import ajaajaja.debugging_rounge.feature.answer.api.dto.AnswerDetailResponse;
 import ajaajaja.debugging_rounge.feature.answer.application.dto.AnswerDetailDto;
-import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface AnswerMapper {
-    @Mapping(target = "loginUserId", expression = "java(loginUserId)")
-    AnswerDetailResponse toResponse(AnswerDetailDto dto, @Context Long loginUserId);
+    @Mapping(target = "mine",
+            expression = "java( loginUserId != null && java.util.Objects.equals(answerDetailDto.userId(), loginUserId))")
+    AnswerDetailResponse toResponse(AnswerDetailDto answerDetailDto, Long loginUserId);
 }

--- a/src/main/java/ajaajaja/debugging_rounge/feature/question/api/QuestionController.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/question/api/QuestionController.java
@@ -1,6 +1,6 @@
 package ajaajaja.debugging_rounge.feature.question.api;
 
-import ajaajaja.debugging_rounge.common.security.annotation.CurrentUserId;
+import ajaajaja.debugging_rounge.common.security.annotation.LoginUserId;
 import ajaajaja.debugging_rounge.common.util.UriHelper;
 import ajaajaja.debugging_rounge.feature.question.api.dto.QuestionCreateRequest;
 import ajaajaja.debugging_rounge.feature.question.api.dto.QuestionDetailResponse;
@@ -33,7 +33,7 @@ public class QuestionController {
 
     @PostMapping
     public ResponseEntity<Long> createQuestion(
-            @CurrentUserId Long userId,
+            @LoginUserId Long userId,
             @RequestBody @Valid QuestionCreateRequest questionCreateRequest) {
 
         QuestionCreateDto questionCreateDto =
@@ -48,12 +48,10 @@ public class QuestionController {
     @GetMapping("/{questionId}")
     public ResponseEntity<QuestionDetailResponse> findQuestion(
             @PathVariable("questionId") Long questionId,
-            @CurrentUserId(required = false) Long userId) {
+            @LoginUserId(required = false) Long loginUserId) {
         QuestionDetailDto questionDetailDto = getQuestionDetailQuery.findQuestionById(questionId);
-        QuestionDetailResponse questionDetailResponse = questionMapper.toResponse(questionDetailDto);
-        if (userId != null) {
-            questionDetailResponse.addLoginUserId(userId);
-        }
+        QuestionDetailResponse questionDetailResponse = questionMapper.toResponse(questionDetailDto, loginUserId);
+
         return ResponseEntity.ok(questionDetailResponse);
     }
 
@@ -67,7 +65,7 @@ public class QuestionController {
     public ResponseEntity<Void> updateQuestion(
             @PathVariable("questionId") Long questionId,
             @RequestBody @Valid QuestionUpdateRequest questionUpdateRequest,
-            @CurrentUserId Long loginUserId
+            @LoginUserId Long loginUserId
     ){
         QuestionUpdateDto questionUpdateDto = QuestionUpdateDto.of(
                 questionId, questionUpdateRequest.title(), questionUpdateRequest.content(), loginUserId);
@@ -79,7 +77,7 @@ public class QuestionController {
     @DeleteMapping("/{questionId}")
     public ResponseEntity<Void> deleteQuestion(
             @PathVariable("questionId") Long questionId,
-            @CurrentUserId Long loginUserId){
+            @LoginUserId Long loginUserId){
         deleteQuestionUseCase.deleteQuestion(questionId, loginUserId);
 
         return ResponseEntity.noContent().build();

--- a/src/main/java/ajaajaja/debugging_rounge/feature/question/api/dto/QuestionDetailResponse.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/question/api/dto/QuestionDetailResponse.java
@@ -11,11 +11,6 @@ public class QuestionDetailResponse {
     private String title;
     private String content;
     private String authorEmail;
-    private Long authorId;
-    private Long loginUserId;
-
-    public void addLoginUserId(Long loginUserId) {
-        this.loginUserId = loginUserId;
-    }
+    private Boolean mine;
 
 }

--- a/src/main/java/ajaajaja/debugging_rounge/feature/question/api/mapper/QuestionMapper.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/question/api/mapper/QuestionMapper.java
@@ -10,7 +10,9 @@ import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface QuestionMapper {
-    QuestionDetailResponse toResponse(QuestionDetailDto questionDetailDto);
+    @Mapping(target = "mine",
+            expression = "java( loginUserId != null && java.util.Objects.equals(questionDetailDto.authorId(), loginUserId))")
+    QuestionDetailResponse toResponse(QuestionDetailDto questionDetailDto, Long loginUserId);
 
     @Mapping(target = "previewContent", source = "previewContent", qualifiedByName = "clean")
     QuestionListResponse toResponse(QuestionListDto dto);

--- a/src/main/java/ajaajaja/debugging_rounge/feature/user/api/UserController.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/user/api/UserController.java
@@ -1,6 +1,6 @@
 package ajaajaja.debugging_rounge.feature.user.api;
 
-import ajaajaja.debugging_rounge.common.security.annotation.CurrentUserId;
+import ajaajaja.debugging_rounge.common.security.annotation.LoginUserId;
 import ajaajaja.debugging_rounge.feature.user.api.dto.UserProfileResponse;
 import ajaajaja.debugging_rounge.feature.user.api.mapper.UserMapper;
 import ajaajaja.debugging_rounge.feature.user.application.dto.UserProfileDto;
@@ -20,7 +20,7 @@ public class UserController {
     private final UserMapper userMapper;
 
     @GetMapping("/me")
-    public ResponseEntity<UserProfileResponse> getCurrentUserProfile(@CurrentUserId Long userId) {
+    public ResponseEntity<UserProfileResponse> getCurrentUserProfile(@LoginUserId Long userId) {
         UserProfileDto userProfile = getUserProfileQuery.getUserProfile(userId);
         return ResponseEntity.ok(userMapper.toResponse(userProfile));
     }


### PR DESCRIPTION
클라이언트는 믿을 수 없고, 서버가 소유자/권한을 판단해야 한다고 생각하고 서버만이 최신 DB를 가지고 있고 또한, 한 트랜잭션 안에 조회 및 판단을 할 수 있기 때문에 변경.