### PR TITLE
fix: 로그아웃 로직에서 리프레쉬 토큰 중복 폐기 코드 수정

### DIFF
--- a/src/main/java/ajaajaja/debugging_rounge/feature/auth/application/port/out/BlacklistedRefreshTokenPort.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/auth/application/port/out/BlacklistedRefreshTokenPort.java
@@ -1,12 +1,12 @@
 package ajaajaja.debugging_rounge.feature.auth.application.port.out;
 
-import ajaajaja.debugging_rounge.feature.auth.domain.BlacklistedRefreshToken;
+import java.util.List;
 
 public interface BlacklistedRefreshTokenPort {
 
-    BlacklistedRefreshToken revoke(BlacklistedRefreshToken blacklistedRefreshToken);
-
     Boolean isRevoked(byte[] tokenHash);
 
-    int insertIfNotExists(byte[] tokenHash, Long userId);
+    void addToBlacklist(byte[] tokenHash, Long userId);
+
+    void addAllToBlacklist(List<byte[]> tokenHashes, Long userId);
 }

--- a/src/main/java/ajaajaja/debugging_rounge/feature/auth/application/port/out/RefreshTokenPort.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/auth/application/port/out/RefreshTokenPort.java
@@ -1,6 +1,5 @@
 package ajaajaja.debugging_rounge.feature.auth.application.port.out;
 
-import ajaajaja.debugging_rounge.feature.auth.domain.BlacklistedRefreshToken;
 import ajaajaja.debugging_rounge.feature.auth.domain.RefreshToken;
 
 import java.util.List;
@@ -13,7 +12,7 @@ public interface RefreshTokenPort {
 
     void deleteByTokenHashAndUserId(byte[] tokenHash, Long userId);
 
-    void killAllSessions(List<BlacklistedRefreshToken> blacklisted, Long userId);
+    void deleteAllByUserId(Long userId);
 
     void save(RefreshToken refreshToken);
 

--- a/src/main/java/ajaajaja/debugging_rounge/feature/auth/infrastructure/persistence/adapter/BlacklistedRefreshTokenRepositoryAdapter.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/auth/infrastructure/persistence/adapter/BlacklistedRefreshTokenRepositoryAdapter.java
@@ -6,6 +6,8 @@ import ajaajaja.debugging_rounge.feature.auth.infrastructure.persistence.Blackli
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+
 @Component
 @RequiredArgsConstructor
 public class BlacklistedRefreshTokenRepositoryAdapter implements BlacklistedRefreshTokenPort {
@@ -13,17 +15,20 @@ public class BlacklistedRefreshTokenRepositoryAdapter implements BlacklistedRefr
     private final BlacklistedRefreshTokenRepository blacklistedRefreshTokenRepository;
 
     @Override
-    public BlacklistedRefreshToken revoke(BlacklistedRefreshToken blacklistedRefreshToken) {
-        return blacklistedRefreshTokenRepository.save(blacklistedRefreshToken);
-    }
-
-    @Override
     public Boolean isRevoked(byte[] tokenHash) {
         return blacklistedRefreshTokenRepository.existsByTokenHash(tokenHash);
     }
 
     @Override
-    public int insertIfNotExists(byte[] tokenHash, Long userId) {
-        return blacklistedRefreshTokenRepository.insertIgnore(tokenHash, userId);
+    public void addToBlacklist(byte[] tokenHash, Long userId) {
+        blacklistedRefreshTokenRepository.insertIgnore(tokenHash, userId);
+    }
+
+    @Override
+    public void addAllToBlacklist(List<byte[]> tokenHashes, Long userId) {
+        List<BlacklistedRefreshToken> blacklisted = tokenHashes.stream()
+                .map(tokenHash -> BlacklistedRefreshToken.of(tokenHash, userId))
+                .toList();
+        blacklistedRefreshTokenRepository.saveAll(blacklisted);
     }
 }

--- a/src/main/java/ajaajaja/debugging_rounge/feature/auth/infrastructure/persistence/adapter/RefreshTokenRepositoryAdapter.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/auth/infrastructure/persistence/adapter/RefreshTokenRepositoryAdapter.java
@@ -1,9 +1,7 @@
 package ajaajaja.debugging_rounge.feature.auth.infrastructure.persistence.adapter;
 
 import ajaajaja.debugging_rounge.feature.auth.application.port.out.RefreshTokenPort;
-import ajaajaja.debugging_rounge.feature.auth.domain.BlacklistedRefreshToken;
 import ajaajaja.debugging_rounge.feature.auth.domain.RefreshToken;
-import ajaajaja.debugging_rounge.feature.auth.infrastructure.persistence.BlacklistedRefreshTokenRepository;
 import ajaajaja.debugging_rounge.feature.auth.infrastructure.persistence.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -16,7 +14,6 @@ import java.util.Optional;
 public class RefreshTokenRepositoryAdapter implements RefreshTokenPort {
 
     private final RefreshTokenRepository refreshTokenRepository;
-    private final BlacklistedRefreshTokenRepository blacklistedRefreshTokenRepository;
 
     @Override
     public Optional<RefreshToken> findByUserId(Long userId) {
@@ -31,14 +28,11 @@ public class RefreshTokenRepositoryAdapter implements RefreshTokenPort {
     @Override
     public void deleteByTokenHashAndUserId(byte[] tokenHash, Long userId) {
         refreshTokenRepository.deleteByTokenHashAndUserId(tokenHash, userId);
-        blacklistedRefreshTokenRepository.save(BlacklistedRefreshToken.of(tokenHash, userId));
     }
 
     @Override
-    public void killAllSessions(List<BlacklistedRefreshToken> blacklisted, Long userId) {
-        blacklistedRefreshTokenRepository.saveAll(blacklisted);
+    public void deleteAllByUserId(Long userId) {
         refreshTokenRepository.deleteAllByUserId(userId);
-
     }
 
     @Override


### PR DESCRIPTION
- RefreTokenAdapter에서도 BlacklistedRefreshTokenRepository을 상속받아 중복해서 폐기된 토큰을 저장하여 중복 폐기로 인한 DB 유니크 에러 발생

- blacklistedRefreshTokenPort.addToBlacklist에서만 폐기된 리프레쉬 토큰을 저장할 수 있게 변경