### PR TITLE
refactor: 모든 API 엔드포인트에 /api 접두어 추가

### DIFF
--- a/src/main/java/ajaajaja/debugging_rounge/common/OpenApiConfig.java
+++ b/src/main/java/ajaajaja/debugging_rounge/common/OpenApiConfig.java
@@ -47,7 +47,8 @@ public class OpenApiConfig {
                                 "토큰 재발급 및 로그아웃 시 Refresh Token이 필요합니다:\n" +
                                 "- **쿠키 형식:** `refreshToken={refreshToken}` (경로: `/auth`)\n" +
                                 "- **Swagger UI에서:** 상단 'Authorize' 버튼 → `refresh-token-cookie`에 Refresh Token 입력\n" +
-                                "- **참고:** 브라우저 개발자 도구에서 쿠키를 확인할 때 경로가 `/auth`인 쿠키만 표시됩니다\n\n" +
+                                "- **참고:** 브라우저 개발자 도구에서 쿠키를 확인할 때 경로가 `/auth`인 쿠키만 표시됩니다\n" +
+                                "  - 실제 API 요청 시에는 context-path가 적용되어 `/api/auth`로 요청됩니다\n\n" +
                                 "### 4. 자동 인증 (브라우저 쿠키 활용)\n" +
                                 "**중요:** 브라우저에서 이미 로그인한 상태라면, Swagger UI에서 별도로 토큰을 입력하지 않아도 됩니다:\n" +
                                 "- 브라우저에 저장된 쿠키(`refreshToken`)가 자동으로 전달됩니다\n" +

--- a/src/main/java/ajaajaja/debugging_rounge/feature/auth/api/AuthController.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/auth/api/AuthController.java
@@ -37,7 +37,7 @@ public class AuthController {
             description = "Refresh Token을 사용하여 새로운 Access Token과 Refresh Token을 발급받습니다.\n\n" +
                     "**테스트 방법:**\n" +
                     "1. 구글 로그인을 통해 Refresh Token을 획득\n" +
-                    "2. 브라우저 개발자 도구를 통해 refreshToken 쿠키 값을 확인(경로가 '/auth' 이어야지만 쿠키 보임)\n" +
+                    "2. 브라우저 개발자 도구를 통해 refreshToken 쿠키 값을 확인(경로가 '/auth' 이어야지만 쿠키 보임, 실제 요청은 context-path가 적용되어 '/api/auth')\n" +
                     "3. Swagger UI에서 상단 'Authorize' 버튼 클릭\n" +
                     "4. 'refresh-token-cookie'에 Refresh Token 값 입력\n" +
                     "5. 'Authorize' 클릭",
@@ -71,7 +71,7 @@ public class AuthController {
             description = "사용자를 로그아웃하고 Refresh Token을 무효화합니다.\n\n" +
                     "**테스트 방법:**\n" +
                     "1. 구글 로그인을 통해 Refresh Token을 획득\n" +
-                    "2. 브라우저 개발자 도구를 통해 refreshToken 쿠키 값을 확인(경로가 '/auth' 이어야지만 쿠키 보임)\n" +
+                    "2. 브라우저 개발자 도구를 통해 refreshToken 쿠키 값을 확인(경로가 '/auth' 이어야지만 쿠키 보임, 실제 요청은 context-path가 적용되어 '/api/auth')\n" +
                     "3. Swagger UI에서 상단 'Authorize' 버튼 클릭\n" +
                     "4. 'refresh-token-cookie'에 Refresh Token 값 입력\n" +
                     "5. 'Authorize' 클릭",

--- a/src/main/java/ajaajaja/debugging_rounge/feature/auth/infrastructure/oauth/CustomOAuth2User.java
+++ b/src/main/java/ajaajaja/debugging_rounge/feature/auth/infrastructure/oauth/CustomOAuth2User.java
@@ -1,9 +1,13 @@
 package ajaajaja.debugging_rounge.feature.auth.infrastructure.oauth;
 
 import ajaajaja.debugging_rounge.feature.user.domain.model.User;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
@@ -11,10 +15,13 @@ import java.util.Collections;
 import java.util.Map;
 
 @RequiredArgsConstructor
-public class CustomOAuth2User implements OAuth2User {
+@Getter
+public class CustomOAuth2User implements OAuth2User, OidcUser {
 
     private final User user;
     private final Map<String, Object> attributes;
+    private final OAuth2User delegate;
+    
     @Override
     public Map<String, Object> getAttributes() {
         return attributes;
@@ -30,4 +37,19 @@ public class CustomOAuth2User implements OAuth2User {
         return String.valueOf(user.getId());
     }
 
+    // OidcUser 메서드들
+    @Override
+    public Map<String, Object> getClaims() {
+        return delegate instanceof OidcUser ? ((OidcUser) delegate).getClaims() : attributes;
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return delegate instanceof OidcUser ? ((OidcUser) delegate).getUserInfo() : null;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return delegate instanceof OidcUser ? ((OidcUser) delegate).getIdToken() : null;
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,10 @@ spring:
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+server:
+  servlet:
+    context-path: /api
+
   jpa:
     hibernate:
       ddl-auto: validate
@@ -48,7 +52,7 @@ jwt:
 
   cookie:
     name: refreshToken
-    path: /auth
+    path: /api/auth
     max-age: 14d
     same-site: None
     secure: true

--- a/src/test/java/ajaajaja/debugging_rounge/feature/answer/application/AnswerFacadeTest.java
+++ b/src/test/java/ajaajaja/debugging_rounge/feature/answer/application/AnswerFacadeTest.java
@@ -12,6 +12,8 @@ import ajaajaja.debugging_rounge.feature.answer.domain.exception.AnswerNotFoundE
 import ajaajaja.debugging_rounge.feature.answer.domain.exception.AnswerNotFoundForDeleteException;
 import ajaajaja.debugging_rounge.feature.answer.domain.exception.AnswerUpdateForbiddenException;
 import ajaajaja.debugging_rounge.feature.answer.domain.exception.QuestionDeleteForbiddenException;
+import ajaajaja.debugging_rounge.feature.answer.image.application.AnswerImageService;
+import ajaajaja.debugging_rounge.feature.answer.image.application.port.out.LoadAnswerImagePort;
 import ajaajaja.debugging_rounge.feature.question.application.port.out.LoadQuestionPort;
 import ajaajaja.debugging_rounge.feature.question.domain.exception.QuestionNotFoundException;
 import org.junit.jupiter.api.DisplayName;
@@ -52,6 +54,12 @@ class AnswerFacadeTest {
 
     @Mock
     OwnershipValidator ownershipValidator;
+
+    @Mock
+    AnswerImageService answerImageService;
+
+    @Mock
+    LoadAnswerImagePort loadAnswerImagePort;
 
     @InjectMocks
     AnswerFacade answerFacade;

--- a/src/test/java/ajaajaja/debugging_rounge/feature/auth/api/AuthControllerTest.java
+++ b/src/test/java/ajaajaja/debugging_rounge/feature/auth/api/AuthControllerTest.java
@@ -130,9 +130,10 @@ class AuthControllerTest {
             doNothing().when(logoutUseCase).logout(refreshToken);
 
             // when & then
-            // Authorization 헤더에 실제 REFRESH 토큰을 넣어 refreshManager가 작동하는지 확인
+            Cookie refreshTokenCookie = new Cookie("refreshToken", refreshToken);
+            
             mockMvc.perform(post("/auth/logout")
-                            .header("Authorization", "Bearer " + refreshToken))
+                            .cookie(refreshTokenCookie))
                     .andExpect(status().isNoContent())
                     .andExpect(header().exists(HttpHeaders.SET_COOKIE))
                     .andExpect(header().string(HttpHeaders.SET_COOKIE,
@@ -160,7 +161,7 @@ class AuthControllerTest {
         void 유효하지않은JWT_401() throws Exception {
             // when & then
             mockMvc.perform(post("/auth/logout")
-                            .header("Authorization", "Bearer invalid.jwt.token"))
+                            .cookie(new Cookie("refreshToken", "invalid.jwt.token")))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.code").value("AUTHENTICATION_FAILED"));
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -24,10 +24,9 @@ spring:
   messages:
     basename: messages/errors
 
-# JWT 설정은 application.yml의 기본값을 사용합니다.
-# 테스트 환경에서만 다른 값이 필요한 경우에만 여기서 오버라이드하세요.
 jwt:
   cookie:
+    path: /api/auth
     secure: false  # 테스트 환경에서는 HTTP 허용
 
 logging:


### PR DESCRIPTION
- 프론트엔드(Vite) 라우팅과 백엔드 API 경로 간의 모호성 제거